### PR TITLE
Pin WTForms version to what it was when first added

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 flask
-WTForms
+WTForms==2.2.1
 flask_mail


### PR DESCRIPTION
The dependency was added in November 2019. Pinning the last version before that which was 2.2.1